### PR TITLE
:memo: Use yarn instead of npm into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@
 
 #### Build Setup
 
+The project use yarn instead of npm for everything :wink:
+
 ``` bash
 # install dependencies
-npm install
+yarn install
 
 # serve with hot reload at localhost:9080
-npm run dev
+yarn run dev
 
 # build electron application for production
-npm run build
+yarn run build
 
 
 # lint all JS/Vue component files in `src/`
-npm run lint
+yarn run lint
 
 ```
 


### PR DESCRIPTION
Enforce `yarn` usage into documentation